### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ bash-toolbelt
 [![Docs Status](https://readthedocs.org/projects/bash-toolbelt/badge/?version=latest)](http://bash-toolbelt.readthedocs.org/en/latest/index.html)
 [![Coverage Status](https://coveralls.io/repos/paulocheque/bash-toolbelt/badge.png?branch=master)](https://coveralls.io/r/paulocheque/bash?branch=master)
 [![Code Status](https://landscape.io/github/paulocheque/bash-toolbelt/master/landscape.png)](https://landscape.io/github/paulocheque/bash-toolbelt/)
-[![PyPi version](https://pypip.in/v/bash-toolbelt/badge.png)](https://crate.io/packages/bash-toolbelt/)
-[![PyPi downloads](https://pypip.in/d/bash-toolbelt/badge.png)](https://crate.io/packages/bash-toolbelt/)
+[![PyPi version](https://img.shields.io/pypi/v/bash-toolbelt.svg)](https://crate.io/packages/bash-toolbelt/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/bash-toolbelt.svg)](https://crate.io/packages/bash-toolbelt/)
 
 **Latest version: 0.0.2 (2016/01)**
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20bash-toolbelt))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `bash-toolbelt`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.